### PR TITLE
Io 및 텍스트 파일 확장자 인식 안되는 버그 고침

### DIFF
--- a/submit.py
+++ b/submit.py
@@ -101,11 +101,9 @@ def get_language(filename):
         return 54
     elif extension in ['.nim']:
         return 55
-    elif extension in ['fs']:
-        return 56
-    elif extension in ['txt']:
+    elif extension in ['.txt']:
         return 58
-    elif extension in ['io']:
+    elif extension in ['.io']:
         return 61
     return -1
 


### PR DESCRIPTION
txt파일과 io파일확장자를 인식할 수 있도록 고쳤습니다.
F#(.fs) 확장자는 이미 있으므로 (82-83번째 줄), 중복으로 보고 하나 지웠습니다.